### PR TITLE
fix(logic): improved name filtering

### DIFF
--- a/addons/sourcemod/scripting/NameFilter.sp
+++ b/addons/sourcemod/scripting/NameFilter.sp
@@ -26,7 +26,7 @@ public Plugin myinfo =
 	author = "BotoX, .Rushaway",
 	description = "Filters player names + Force names",
 	url = "https://github.com/srcdslab/sm-plugin-NameFilter",
-	version = "2.0.3"
+	version = "2.0.4"
 }
 
 public APLRes AskPluginLoad2(Handle myself, bool late, char[] error, int err_max)
@@ -94,7 +94,7 @@ public void OnClientConnected(int client)
 	{
 		DataPack pack = new DataPack();
 		pack.WriteCell(client);
-		pack.WriteString(g_sForcedName);
+		pack.WriteString(sName);
 		RequestFrame(OnFrameRequested, pack);
 	}
 
@@ -205,6 +205,7 @@ public Action Command_ForceName(int client, int args)
 	SetClientName(g_iTarget, Arg2);
 
 	SetUpKeyValues();
+
 	g_Kv.JumpToKey(g_sSteamID, true);
 	g_Kv.SetString("OriginalName", TargetName);
 	g_Kv.SetString("ForcedName", Arg2);
@@ -617,11 +618,11 @@ bool FilterName(int client, char[] sName, int Length = MAX_NAME_LENGTH)
 	{
 		TerminateNameUTF8(sName);
 
-		if (strlen(sName) < 2)
+		if (strlen(sName) < 2 || IsNameOnlyWhitespace(sName))
 		{
 			int RandomName = client % g_ReplacementNames.Length;
 			g_ReplacementNames.GetString(RandomName, sName, Length);
-			NF_DebugLog("Name too short after filter, replacement: '%s'", sName);
+			NF_DebugLog("Name too short or only whitespace after filter, replacement: '%s'", sName);
 			return true;
 		}
 	}
@@ -696,4 +697,15 @@ stock void NF_DebugLog(const char[] fmt, any ...)
 	static char buffer[256];
 	VFormat(buffer, sizeof(buffer), fmt, 2);
 	LogMessage("[NameFilter][DEBUG] %s", buffer);
+}
+
+stock bool IsNameOnlyWhitespace(const char[] name)
+{
+	int len = strlen(name);
+	for (int i = 0; i < len; i++)
+	{
+		if (name[i] != ' ' && name[i] != '\t' && name[i] != '\n' && name[i] != '\r')
+			return false;
+	}
+	return len > 0; // Return true only if it contains at least one whitespace character
 }


### PR DESCRIPTION
This PR fixes:
- Wrong string used in `OnClientConnected` datapack
- Detect "unnamed" name assigned by game engine (this also fix the case if censor value is empty or using space)